### PR TITLE
fix: replace 136 bare excepts with except Exception

### DIFF
--- a/src/components/custom_title_bar.py
+++ b/src/components/custom_title_bar.py
@@ -567,7 +567,7 @@ class CustomTitleBar(ft.Container):
         try:
             if self._page:
                 self.update()
-        except:
+        except Exception:
             pass
     
     def _minimize_window(self, e: ft.ControlEvent) -> None:

--- a/src/services/ai_subtitle_fix_service.py
+++ b/src/services/ai_subtitle_fix_service.py
@@ -218,7 +218,7 @@ class AISubtitleFixService:
                         try:
                             fixed = self.fix_text(text, language)
                             fixed_texts.append(fixed)
-                        except:
+                        except Exception:
                             fixed_texts.append(text)
                 
                 for j, seg in enumerate(batch):
@@ -534,7 +534,7 @@ class AISubtitleFixService:
                         try:
                             translated = self.translate_text(text, target_lang, source_lang)
                             translated_texts.append(translated)
-                        except:
+                        except Exception:
                             translated_texts.append(text)
                 
                 for j, seg in enumerate(batch):

--- a/src/services/auto_updater.py
+++ b/src/services/auto_updater.py
@@ -263,7 +263,7 @@ class AutoUpdater:
                     parent_process = current_process.parent()
                     if parent_process and parent_process.name().lower() in ['flet.exe', 'pythonw.exe', 'python.exe']:
                         process_names.add(parent_process.name())
-                except:
+                except Exception:
                     pass
             except Exception as e:
                 if not _is_packaged_app():

--- a/src/services/ffmpeg_service.py
+++ b/src/services/ffmpeg_service.py
@@ -1468,7 +1468,7 @@ class FFmpegService:
                 try:
                     probe = ffmpeg.probe(str(input_path), cmd=ffprobe_path)
                     duration = float(probe['format']['duration'])
-                except:
+                except Exception:
                     duration = 0.0
             else:
                 duration = 0.0
@@ -1623,7 +1623,7 @@ class FFmpegService:
             duration = 0.0
             try:
                 duration = self.get_video_duration(input_path)
-            except:
+            except Exception:
                 pass
             
             # 构建输入流

--- a/src/services/http_service.py
+++ b/src/services/http_service.py
@@ -278,7 +278,7 @@ class HttpService:
                     response_body = response.json()
                     body_text = json.dumps(response_body, ensure_ascii=False, indent=2)
                     content_type = "application/json"
-                except:
+                except Exception:
                     # 使用文本
                     body_text = response.text
                     content_type = response.headers.get("Content-Type", "text/plain")
@@ -310,7 +310,7 @@ class HttpService:
             for f in opened_files:
                 try:
                     f.close()
-                except:
+                except Exception:
                     pass
     
     def get_curl_command(
@@ -371,7 +371,7 @@ class HttpService:
                         if '=' in line:
                             key, value = line.split('=', 1)
                             parts.append(f'-F "{key.strip()}={value.strip()}"')
-                except:
+                except Exception:
                     pass
         
         # 处理普通请求体
@@ -385,7 +385,7 @@ class HttpService:
                     # 转义单引号
                     json_str = json_str.replace("'", "'\\''")
                     parts.append(f"-d '{json_str}'")
-                except:
+                except Exception:
                     parts.append(f"-d '{body}'")
             elif body_type == "form":
                 # Form 格式：转换为 -d "key=value" 或 --data-urlencode
@@ -395,7 +395,7 @@ class HttpService:
                             key, value = line.split('=', 1)
                             # 使用 --data-urlencode 自动处理编码
                             parts.append(f'--data-urlencode "{key.strip()}={value.strip()}"')
-                except:
+                except Exception:
                     parts.append(f"-d '{body}'")
             else:
                 # Raw 格式

--- a/src/services/icp_service.py
+++ b/src/services/icp_service.py
@@ -321,7 +321,7 @@ class YOLODetector:
             bottom = top + height
             try:
                 box_mid_xy = [(left + width / 2) + 2,(top + height / 2)]
-            except:
+            except Exception:
                 box_mid_xy = [left + width / 2,top + height / 2]
             img = source[top:bottom, left:right]
             try:
@@ -590,7 +590,7 @@ class ICPService:
                 }
                 device_info = device_map.get(provider, provider)
                 logger.info(f"ICP模型运行设备: {device_info}")
-            except:
+            except Exception:
                 pass
             
             return True
@@ -727,7 +727,7 @@ class ICPService:
                 try:
                     error_data = response.json()
                     logger.error(f"错误响应: {error_data}")
-                except:
+                except Exception:
                     logger.error(f"错误响应文本: {response.text[:500]}")
                 return None
                     
@@ -849,7 +849,7 @@ class ICPService:
                 try:
                     error_data = response.json()
                     logger.error(f"  响应JSON: {error_data}")
-                except:
+                except Exception:
                     error_text = response.text[:500] if hasattr(response, 'text') else "无法读取响应文本"
                     logger.error(f"  响应文本(前500字符): {error_text}")
                 return None
@@ -1011,7 +1011,7 @@ class ICPService:
                 try:
                     error_data = response.json()
                     logger.error(f"  错误响应: {error_data}")
-                except:
+                except Exception:
                     logger.error(f"  响应文本: {response.text[:500]}")
                 return False, ""
                     
@@ -1117,7 +1117,7 @@ class ICPService:
                     try:
                         error_data = response.json()
                         logger.error(f"  错误响应: {error_data}")
-                    except:
+                    except Exception:
                         logger.error(f"  响应文本: {response.text[:500]}")
                     await asyncio.sleep(1)
                     continue
@@ -1283,5 +1283,5 @@ class ICPService:
                     loop.create_task(self.session.aclose())
                 else:
                     loop.run_until_complete(self.session.aclose())
-            except:
+            except Exception:
                 pass

--- a/src/services/image_service.py
+++ b/src/services/image_service.py
@@ -1151,7 +1151,7 @@ class ImageService:
                             }
                             info['average_brightness'] = round(float(np.mean(rgb_array)), 2)
                             info['std_deviation'] = round(float(np.std(rgb_array)), 2)
-                except:
+                except Exception:
                     pass
                 
                 # 动画信息（GIF）
@@ -1201,7 +1201,7 @@ class ImageService:
                                         info['gps_latitude'] = lat
                                         info['gps_longitude'] = lon
                                         info['gps_coordinates'] = f"{lat:.6f}, {lon:.6f}"
-                                except:
+                                except Exception:
                                     pass
                             
                             # 提取主要拍摄参数
@@ -1219,7 +1219,7 @@ class ImageService:
                                         camera_data['曝光时间'] = f"{value[0]}/{value[1]}s"
                                     else:
                                         camera_data['曝光时间'] = f"{value}s"
-                                except:
+                                except Exception:
                                     camera_data['曝光时间'] = str(value)
                             elif tag == 'FNumber':
                                 try:
@@ -1227,7 +1227,7 @@ class ImageService:
                                         camera_data['光圈'] = f"f/{value[0]/value[1]:.1f}"
                                     else:
                                         camera_data['光圈'] = f"f/{value:.1f}"
-                                except:
+                                except Exception:
                                     camera_data['光圈'] = str(value)
                             elif tag == 'ISOSpeedRatings':
                                 camera_data['ISO'] = value
@@ -1237,9 +1237,9 @@ class ImageService:
                                         camera_data['焦距'] = f"{value[0]/value[1]:.1f}mm"
                                     else:
                                         camera_data['焦距'] = f"{value:.1f}mm"
-                                except:
+                                except Exception:
                                     camera_data['焦距'] = str(value)
-                except:
+                except Exception:
                     pass
                 
                 info['exif'] = exif_data
@@ -1317,7 +1317,7 @@ class ImageService:
             ascii_chars = ''.join(chr(b) for b in data if 32 <= b < 127)
             if ascii_chars:
                 return ascii_chars.strip()
-        except:
+        except Exception:
             pass
         
         # 最后的选择：返回十六进制表示
@@ -1373,7 +1373,7 @@ class ImageService:
                 decimal = -decimal
             
             return decimal
-        except:
+        except Exception:
             return 0.0
     
     def _detect_live_photo(self, image_path: Path, file_data: bytes) -> Optional[dict]:
@@ -1443,7 +1443,7 @@ class ImageService:
                                 xmp_data = xmp_data_raw.decode('utf-8', errors='ignore')
                             else:
                                 xmp_data = xmp_data_raw
-                except:
+                except Exception:
                     pass
             
             # 如果找到 XMP 数据，检查是否包含 MotionPhoto 标记
@@ -1523,7 +1523,7 @@ class ImageService:
                                         'platform': 'Android',
                                         'detection_method': 'EXIF MakerNote'
                                     }
-            except:
+            except Exception:
                 pass
             
             return None
@@ -1592,7 +1592,7 @@ class ImageService:
                                 if 'iOS' in value or 'iPhone' in value:
                                     # 可能是 iPhone 拍摄的照片，检查其他标记
                                     pass
-                except:
+                except Exception:
                     pass
                 
                 # 检查文件元数据中的 QuickTime 标识

--- a/src/services/speech_recognition_service.py
+++ b/src/services/speech_recognition_service.py
@@ -234,7 +234,7 @@ class SpeechRecognitionService:
                     if temp_path.exists():
                         try:
                             temp_path.unlink()
-                        except:
+                        except Exception:
                             pass
                     raise RuntimeError(f"下载{file_type}失败: {e}")
             
@@ -250,7 +250,7 @@ class SpeechRecognitionService:
                     try:
                         file_path.unlink()
                         logger.warning(f"已删除不完整的文件: {file_path.name}")
-                    except:
+                    except Exception:
                         pass
             raise RuntimeError(f"下载模型失败: {e}")
     
@@ -358,7 +358,7 @@ class SpeechRecognitionService:
                     try:
                         file_path.unlink()
                         logger.warning(f"已删除不完整的文件: {file_path.name}")
-                    except:
+                    except Exception:
                         pass
             raise RuntimeError(f"下载 SenseVoice 模型失败: {e}")
     

--- a/src/services/translate_service.py
+++ b/src/services/translate_service.py
@@ -139,7 +139,7 @@ class TranslateService:
                 
                 try:
                     data = resp.json()
-                except:
+                except Exception:
                     logger.error(f"翻译响应解析失败: {resp.text}")
                     return {
                         "code": 500,

--- a/src/utils/onnx_helper.py
+++ b/src/utils/onnx_helper.py
@@ -78,7 +78,7 @@ def _get_cuda_device_count() -> int:
             lines = [l.strip() for l in result.stdout.strip().split('\n') if l.strip()]
             _cached_cuda_device_count = len(lines)
             return _cached_cuda_device_count
-    except:
+    except Exception:
         pass
     
     # 未检测到 NVIDIA GPU

--- a/src/views/dev_tools/json_viewer_view.py
+++ b/src/views/dev_tools/json_viewer_view.py
@@ -662,7 +662,7 @@ class JsonTreeNode(ft.Container):
                 if hasattr(current, 'page') and current.page is not None:
                     return current.page
                 current = getattr(current, 'parent', None)
-        except:
+        except Exception:
             pass
             
         return None
@@ -694,7 +694,7 @@ class JsonTreeNode(ft.Container):
             if hasattr(page, 'dialog') and page.dialog:
                 try:
                     page.close(page.dialog)
-                except:
+                except Exception:
                     pass
             
             # 创建小型弹出菜单

--- a/src/views/dev_tools/jwt_tool_view.py
+++ b/src/views/dev_tools/jwt_tool_view.py
@@ -319,7 +319,7 @@ class JwtToolView(ft.Container):
                                 days = hours / 24
                                 formatted_lines.append(f"  ✓ 剩余 {days:.1f} 天")
                     formatted_lines.append("")
-                except:
+                except Exception:
                     pass
         
         return '\n'.join(formatted_lines)

--- a/src/views/dev_tools/port_scanner_view.py
+++ b/src/views/dev_tools/port_scanner_view.py
@@ -387,7 +387,7 @@ class PortScannerView(ft.Container):
         if not service_name:
             try:
                 service_name = socket.getservbyport(port)
-            except:
+            except Exception:
                 service_name = "未知服务"
         
         result_lines.append(f"服务: {service_name}\n")
@@ -457,7 +457,7 @@ class PortScannerView(ft.Container):
             if not service_name:
                 try:
                     service_name = socket.getservbyport(port)
-                except:
+                except Exception:
                     service_name = "未知"
             
             if is_open:
@@ -606,7 +606,7 @@ class PortScannerView(ft.Container):
                 if not service_name:
                     try:
                         service_name = socket.getservbyport(port)
-                    except:
+                    except Exception:
                         service_name = "未知"
                 
                 open_ports.append((port, service_name, response_time))

--- a/src/views/dev_tools/text_diff_view.py
+++ b/src/views/dev_tools/text_diff_view.py
@@ -824,7 +824,7 @@ class TextDiffView(ft.Container):
             except UnicodeDecodeError:
                 try:
                     return path.read_text(encoding='gbk')
-                except:
+                except Exception:
                     return path.read_text(encoding='latin-1')
         
         # 加载第一个文件到左侧

--- a/src/views/image/background_view.py
+++ b/src/views/image/background_view.py
@@ -1142,7 +1142,7 @@ class ImageBackgroundView(ft.Container):
         
         try:
             self.file_list_view.update()
-        except:
+        except Exception:
             pass
         
         # 更新 GIF 选项
@@ -1227,7 +1227,7 @@ class ImageBackgroundView(ft.Container):
             
             try:
                 self.gif_files_list.update()
-            except:
+            except Exception:
                 pass
         else:
             # 隐藏 GIF 选项
@@ -1235,7 +1235,7 @@ class ImageBackgroundView(ft.Container):
         
         try:
             self.gif_options.update()
-        except:
+        except Exception:
             pass
     
     def _on_gif_prev_frame(self, gif_file: Path, frame_count: int) -> None:
@@ -1451,7 +1451,7 @@ class ImageBackgroundView(ft.Container):
         try:
             # 一次性更新整个页面，而不是分别更新两个控件
             self._page.update()
-        except:
+        except Exception:
             pass
     
     def _on_process_complete(self, success_count: int, total: int, output_dir: Path, oom_error_count: int = 0) -> None:
@@ -1472,7 +1472,7 @@ class ImageBackgroundView(ft.Container):
         try:
             # 一次性更新页面，提高响应速度
             self._page.update()
-        except:
+        except Exception:
             pass
         
         # 如果有显存不足错误，优先显示警告
@@ -1580,7 +1580,7 @@ class ImageBackgroundView(ft.Container):
         
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     def cleanup(self) -> None:

--- a/src/views/image/border_view.py
+++ b/src/views/image/border_view.py
@@ -667,7 +667,7 @@ class ImageBorderView(ft.Container):
         
         try:
             self.gif_info_banner.update()
-        except:
+        except Exception:
             pass
     
     def _remove_file(self, file_path: Path) -> None:

--- a/src/views/image/crop_view.py
+++ b/src/views/image/crop_view.py
@@ -794,7 +794,7 @@ class ImageCropView(ft.Container):
         self._update_theme_colors()
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
 
     def _update_max_canvas_constraints(self) -> None:
@@ -1281,7 +1281,7 @@ class ImageCropView(ft.Container):
             try:
                 self._page.update()
                 self._last_update_time = current_time
-            except:
+            except Exception:
                 pass
 
     def _update_crop_box_position_data(self) -> None:
@@ -1385,7 +1385,7 @@ class ImageCropView(ft.Container):
         if not skip_update:
             try:
                 self._page.update()
-            except:
+            except Exception:
                 pass
 
     def _update_rulers(self) -> None:
@@ -1629,7 +1629,7 @@ class ImageCropView(ft.Container):
         if self._preview_update_timer is not None:
             try:
                 self._preview_update_timer.cancel()
-            except:
+            except Exception:
                 pass
 
         # 设置新的定时器,200ms后更新预览
@@ -1676,7 +1676,7 @@ class ImageCropView(ft.Container):
 
             try:
                 self._page.update()
-            except:
+            except Exception:
                 pass
 
             # UI更新完成后再删除旧文件
@@ -1685,7 +1685,7 @@ class ImageCropView(ft.Container):
                     old_path = Path(old_preview_path)
                     if old_path.exists() and old_path != preview_path:
                         old_path.unlink()
-                except:
+                except Exception:
                     pass
 
         except Exception as ex:

--- a/src/views/image/enhance_view.py
+++ b/src/views/image/enhance_view.py
@@ -1224,7 +1224,7 @@ class ImageEnhanceView(ft.Container):
         
         try:
             self.file_list_view.update()
-        except:
+        except Exception:
             pass
     
     def _on_remove_file(self, index: int) -> None:
@@ -1539,7 +1539,7 @@ class ImageEnhanceView(ft.Container):
         
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     def cleanup(self) -> None:

--- a/src/views/image/info_view.py
+++ b/src/views/image/info_view.py
@@ -241,7 +241,7 @@ class ImageInfoView(ft.Container):
             self._update_summary_section_theme()
             try:
                 self._page.update()
-            except:
+            except Exception:
                 pass
 
     def _init_empty_state(self) -> None:
@@ -717,7 +717,7 @@ class ImageInfoView(ft.Container):
                                 value = f"{value[0]}/{value[1]}"
                             else:
                                 value = str(value[0])
-                        except:
+                        except Exception:
                             value = str(value)
                     else:
                         value = str(value)
@@ -1193,7 +1193,7 @@ class ImageInfoView(ft.Container):
                                 value = f"{value[0]}/{value[1]}"
                             else:
                                 value = str(value[0])
-                        except:
+                        except Exception:
                             value = str(value)
                     else:
                         value = str(value)
@@ -1282,7 +1282,7 @@ class ImageInfoView(ft.Container):
                                 subprocess.run(['open', '-R', str(output_path)])
                             else:  # Linux
                                 subprocess.run(['xdg-open', str(folder_path)])
-                        except:
+                        except Exception:
                             pass
                         
                         self._page.close(confirm_dialog)

--- a/src/views/image/ocr_view.py
+++ b/src/views/image/ocr_view.py
@@ -756,7 +756,7 @@ class OCRView(ft.Container):
             self._show_snackbar("至少需要选择一种输出格式", ft.Colors.ORANGE)
             try:
                 self._page.update()
-            except:
+            except Exception:
                 pass
         
         # 保存配置
@@ -778,7 +778,7 @@ class OCRView(ft.Container):
         
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     async def _on_browse_output(self, e: ft.ControlEvent) -> None:
@@ -789,7 +789,7 @@ class OCRView(ft.Container):
             self.custom_output_dir.value = result
             try:
                 self._page.update()
-            except:
+            except Exception:
                 pass
     
     def _on_download_model(self, e: ft.ControlEvent) -> None:
@@ -1380,10 +1380,10 @@ class OCRView(ft.Container):
                         font_size = max(int(box_height * 0.8), 12)
                         # Windows 中文字体
                         pil_font = ImageFont.truetype("msyh.ttc", font_size)  # 微软雅黑
-                    except:
+                    except Exception:
                         try:
                             pil_font = ImageFont.truetype("simhei.ttf", font_size)  # 黑体
-                        except:
+                        except Exception:
                             pil_font = ImageFont.load_default()
                     
                     # 绘制文字

--- a/src/views/image/puzzle/merge_view.py
+++ b/src/views/image/puzzle/merge_view.py
@@ -1104,9 +1104,9 @@ class ImagePuzzleMergeView(ft.Container):
                 if old_file != preview_path:
                     try:
                         old_file.unlink()
-                    except:
+                    except Exception:
                         pass
-        except:
+        except Exception:
             pass
         
         # 直接使用文件路径显示
@@ -1162,9 +1162,9 @@ class ImagePuzzleMergeView(ft.Container):
                 if old_file != preview_path:
                     try:
                         old_file.unlink()
-                    except:
+                    except Exception:
                         pass
-        except:
+        except Exception:
             pass
         
         # 直接使用文件路径显示

--- a/src/views/image/puzzle/split_view.py
+++ b/src/views/image/puzzle/split_view.py
@@ -796,9 +796,9 @@ class ImagePuzzleSplitView(ft.Container):
                                     if old_file != temp_path:
                                         try:
                                             old_file.unlink()
-                                        except:
+                                        except Exception:
                                             pass
-                            except:
+                            except Exception:
                                 pass
                             
                             self.original_image_widget.src = str(temp_path)
@@ -1324,9 +1324,9 @@ class ImagePuzzleSplitView(ft.Container):
                 if old_file != preview_path:
                     try:
                         old_file.unlink()
-                    except:
+                    except Exception:
                         pass
-        except:
+        except Exception:
             pass
         
         # 直接使用文件路径显示
@@ -1419,9 +1419,9 @@ class ImagePuzzleSplitView(ft.Container):
                 if old_file != preview_path:
                     try:
                         old_file.unlink()
-                    except:
+                    except Exception:
                         pass
-        except:
+        except Exception:
             pass
         
         # 直接使用文件路径显示
@@ -2082,9 +2082,9 @@ class ImagePuzzleSplitView(ft.Container):
                         if old_file != temp_path:
                             try:
                                 old_file.unlink()
-                            except:
+                            except Exception:
                                 pass
-                except:
+                except Exception:
                     pass
                 
                 self.original_image_widget.src = str(temp_path)

--- a/src/views/image/remove_exif_view.py
+++ b/src/views/image/remove_exif_view.py
@@ -318,7 +318,7 @@ class ImageRemoveExifView(ft.Container):
                     if isinstance(value, bytes):
                         try:
                             value_str = value.decode('utf-8', errors='ignore')
-                        except:
+                        except Exception:
                             value_str = str(value)
                     else:
                         value_str = str(value)

--- a/src/views/image/resize_view.py
+++ b/src/views/image/resize_view.py
@@ -628,7 +628,7 @@ class ImageResizeView(ft.Container):
         
         try:
             self.gif_info_banner.update()
-        except:
+        except Exception:
             pass
     
     def _remove_file(self, file_path: Path) -> None:

--- a/src/views/image/rotate_view.py
+++ b/src/views/image/rotate_view.py
@@ -908,7 +908,7 @@ class ImageRotateView(ft.Container):
                 # 自定义角度旋转
                 try:
                     angle = float(self.custom_angle_field.value)
-                except:
+                except Exception:
                     angle = 0
                 
                 # 使用当前填充颜色
@@ -1011,7 +1011,7 @@ class ImageRotateView(ft.Container):
                                 # 自定义角度旋转
                                 try:
                                     angle = float(self.custom_angle_field.value)
-                                except:
+                                except Exception:
                                     angle = 0
                                 
                                 # 使用当前填充颜色
@@ -1044,7 +1044,7 @@ class ImageRotateView(ft.Container):
                             # 自定义角度旋转
                             try:
                                 angle = float(self.custom_angle_field.value)
-                            except:
+                            except Exception:
                                 angle = 0
                             
                             # 使用当前填充颜色

--- a/src/views/image/watermark_view.py
+++ b/src/views/image/watermark_view.py
@@ -1193,19 +1193,19 @@ class ImageWatermarkView(ft.Container):
             for font_file in font_map[font_choice]:
                 try:
                     return ImageFont.truetype(font_file, font_size)
-                except:
+                except Exception:
                     continue
         
         # 如果选择的字体加载失败，尝试微软雅黑
         try:
             return ImageFont.truetype("msyh.ttc", font_size)
-        except:
+        except Exception:
             pass
         
         # 最后尝试 Arial
         try:
             return ImageFont.truetype("arial.ttf", font_size)
-        except:
+        except Exception:
             pass
         
         # 都失败了，返回默认字体
@@ -1300,7 +1300,7 @@ class ImageWatermarkView(ft.Container):
                 try:
                     file_size = file_path.stat().st_size
                     size_str = f"{file_size / 1024:.1f} KB" if file_size < 1024 * 1024 else f"{file_size / (1024 * 1024):.2f} MB"
-                except:
+                except Exception:
                     size_str = "未知"
                 
                 self.file_list_view.controls.append(
@@ -1382,7 +1382,7 @@ class ImageWatermarkView(ft.Container):
         self.browse_output_button.disabled = not is_custom
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     async def _on_browse_output(self, e: ft.ControlEvent) -> None:
@@ -1392,7 +1392,7 @@ class ImageWatermarkView(ft.Container):
             self.custom_output_dir.value = folder_path
             try:
                 self._page.update()
-            except:
+            except Exception:
                 pass
     
     def _on_preview(self, e: Optional[ft.ControlEvent]) -> None:

--- a/src/views/media/audio_to_text_view.py
+++ b/src/views/media/audio_to_text_view.py
@@ -1101,7 +1101,7 @@ class AudioToTextView(ft.Container):
         
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     def _try_auto_load_model(self) -> None:
@@ -1180,7 +1180,7 @@ class AudioToTextView(ft.Container):
         
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     def _on_model_change(self, e: ft.ControlEvent) -> None:
@@ -1458,7 +1458,7 @@ class AudioToTextView(ft.Container):
             self._update_process_button()
             try:
                 self._page.update()
-            except:
+            except Exception:
                 pass
     
     def _on_delete_model(self, e: ft.ControlEvent) -> None:
@@ -1536,7 +1536,7 @@ class AudioToTextView(ft.Container):
                 if model_dir.exists() and not any(model_dir.iterdir()):
                     model_dir.rmdir()
                     logger.info(f"模型目录已删除: {model_dir.name}")
-            except:
+            except Exception:
                 pass
             
             # 更新状态
@@ -1555,7 +1555,7 @@ class AudioToTextView(ft.Container):
         
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     def _on_auto_load_change(self, e: ft.ControlEvent) -> None:
@@ -1675,7 +1675,7 @@ class AudioToTextView(ft.Container):
                     self.vad_status_text.value = message
                     try:
                         self._page.update()
-                    except:
+                    except Exception:
                         pass
                 
                 self.vad_service.download_model(
@@ -1747,7 +1747,7 @@ class AudioToTextView(ft.Container):
                     self.vocal_status_text.value = message
                     try:
                         self._page.update()
-                    except:
+                    except Exception:
                         pass
                 
                 self.vocal_service.download_model(
@@ -1858,7 +1858,7 @@ class AudioToTextView(ft.Container):
                 self.punctuation_status_text.value = "下载模型文件..."
                 try:
                     self._page.update()
-                except:
+                except Exception:
                     pass
                 
                 response = requests.get(punctuation_model_info.model_url, stream=True, timeout=120)
@@ -1877,14 +1877,14 @@ class AudioToTextView(ft.Container):
                                 self.punctuation_status_text.value = f"下载模型... {progress:.0f}%"
                                 try:
                                     self._page.update()
-                                except:
+                                except Exception:
                                     pass
                 
                 # 下载 tokens 文件
                 self.punctuation_status_text.value = "下载 tokens 文件..."
                 try:
                     self._page.update()
-                except:
+                except Exception:
                     pass
                 
                 response = requests.get(punctuation_model_info.tokens_url, timeout=60)
@@ -1973,7 +1973,7 @@ class AudioToTextView(ft.Container):
         self.subtitle_length_text.value = f"每段最大 {self.subtitle_max_length} 字"
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     def _on_subtitle_keep_punct_change(self, e: ft.ControlEvent) -> None:
@@ -1989,7 +1989,7 @@ class AudioToTextView(ft.Container):
         self.browse_output_button.disabled = not is_custom
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     async def _on_browse_output(self, e: ft.ControlEvent) -> None:
@@ -1999,7 +1999,7 @@ class AudioToTextView(ft.Container):
             self.custom_output_dir.value = result
             try:
                 self._page.update()
-            except:
+            except Exception:
                 pass
     
     async def _on_select_files(self, e: ft.ControlEvent = None) -> None:
@@ -2040,7 +2040,7 @@ class AudioToTextView(ft.Container):
         self._update_process_button()
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     def _check_has_audio_stream(self, file_path: Path) -> bool:
@@ -2138,7 +2138,7 @@ class AudioToTextView(ft.Container):
         self.file_list_view.controls = file_items
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     def _remove_file(self, file_path: Path) -> None:
@@ -2154,7 +2154,7 @@ class AudioToTextView(ft.Container):
         button.disabled = not (self.selected_files and self.model_loaded and not self.is_processing)
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     def _on_process(self, e: ft.ControlEvent) -> None:

--- a/src/views/media/subtitle_convert_view.py
+++ b/src/views/media/subtitle_convert_view.py
@@ -417,7 +417,7 @@ class SubtitleConvertView(ft.Container):
                 try:
                     size = file_path.stat().st_size
                     size_str = format_file_size(size)
-                except:
+                except Exception:
                     size_str = "未知"
                 
                 item = ft.Container(

--- a/src/views/media/subtitle_remove_view.py
+++ b/src/views/media/subtitle_remove_view.py
@@ -843,7 +843,7 @@ class SubtitleRemoveView(ft.Container):
                     return int(parts[0]) * 60 + float(parts[1])
                 elif len(parts) == 1:
                     return float(parts[0])
-            except:
+            except Exception:
                 pass
             return 0.0
         

--- a/src/views/media/ts_merge_view.py
+++ b/src/views/media/ts_merge_view.py
@@ -463,7 +463,7 @@ class TSMergeView(ft.Container):
                 try:
                     size = file_path.stat().st_size
                     size_str = format_file_size(size)
-                except:
+                except Exception:
                     size_str = "未知"
                 
                 item = ft.Container(

--- a/src/views/media/video_convert_view.py
+++ b/src/views/media/video_convert_view.py
@@ -555,7 +555,7 @@ class VideoConvertView(ft.Container):
         
         try:
             self.file_list_view.update()
-        except:
+        except Exception:
             pass
     
     def _update_convert_button(self) -> None:
@@ -563,7 +563,7 @@ class VideoConvertView(ft.Container):
         self.convert_button.content.disabled = not self.selected_files
         try:
             self.convert_button.update()
-        except:
+        except Exception:
             pass
     
     def _on_output_mode_change(self, e: ft.ControlEvent) -> None:
@@ -574,7 +574,7 @@ class VideoConvertView(ft.Container):
         try:
             self.custom_output_dir.update()
             self.browse_output_button.update()
-        except:
+        except Exception:
             pass
     
     async def _on_browse_output(self, e: ft.ControlEvent) -> None:
@@ -585,7 +585,7 @@ class VideoConvertView(ft.Container):
             self.output_custom_path = Path(result)
             try:
                 self.custom_output_dir.update()
-            except:
+            except Exception:
                 pass
     
     def _start_convert(self, e: ft.ControlEvent) -> None:

--- a/src/views/media/video_enhance_view.py
+++ b/src/views/media/video_enhance_view.py
@@ -1276,7 +1276,7 @@ class VideoEnhanceView(ft.Container):
         
         try:
             self.file_list_view.update()
-        except:
+        except Exception:
             pass
     
     def _on_remove_file(self, index: int) -> None:
@@ -1310,7 +1310,7 @@ class VideoEnhanceView(ft.Container):
             button = self.process_button.content
             button.disabled = not (self.selected_files and self.enhancer)
             self.process_button.update()
-        except:
+        except Exception:
             pass
     
     def _on_cancel(self, e: ft.ControlEvent) -> None:
@@ -1323,7 +1323,7 @@ class VideoEnhanceView(ft.Container):
         try:
             self.cancel_button.update()
             self.progress_text.update()
-        except:
+        except Exception:
             pass
         
         self._show_snackbar("正在取消处理，立即停止并清理资源...", ft.Colors.ORANGE)
@@ -1517,7 +1517,7 @@ class VideoEnhanceView(ft.Container):
                 if estimated_peak_mb > available_memory_mb * 0.5:
                     logger.warning(f"⚠️  高内存占用警告: 估算峰值 {estimated_peak_mb:.0f}MB / 可用 {available_memory_mb:.0f}MB")
                     logger.warning("建议：关闭其他程序或降低视频分辨率")
-            except:
+            except Exception:
                 pass
             
             logger.info("=" * 80)
@@ -1819,7 +1819,7 @@ class VideoEnhanceView(ft.Container):
                                     enhanced_frame_queue.put(None)
                                     return
                                 frame_buffer.append(frame)
-                            except:
+                            except Exception:
                                 break  # 队列空，立即处理
                         
                         # 立即处理收集到的帧（即使不满batch_size）
@@ -1871,7 +1871,7 @@ class VideoEnhanceView(ft.Container):
                     # 🔥 从队列获取增强后的帧（非阻塞检查）
                     try:
                         enhanced_array = enhanced_frame_queue.get(timeout=0.1)
-                    except:
+                    except Exception:
                         continue  # 队列空，继续等待
                     
                     # EOF信号
@@ -1898,7 +1898,7 @@ class VideoEnhanceView(ft.Container):
                             encoder_stderr = encoder_process.stderr.read().decode('utf-8', errors='ignore')
                             if encoder_stderr:
                                 logger.error(f"编码器错误信息: {encoder_stderr}")
-                        except:
+                        except Exception:
                             pass
                         stop_event.set()
                         return False
@@ -1922,7 +1922,7 @@ class VideoEnhanceView(ft.Container):
                                 process = psutil.Process()
                                 memory_mb = process.memory_info().rss / (1024 * 1024)
                                 logger.info(f"内存占用: {memory_mb:.1f} MB (已处理 {frame_idx} 帧)")
-                            except:
+                            except Exception:
                                 pass
                     
                     # 更新进度
@@ -1976,11 +1976,11 @@ class VideoEnhanceView(ft.Container):
                     # 如果还没退出，强制杀死
                     try:
                         decoder_process.kill()
-                    except:
+                    except Exception:
                         pass
                     try:
                         encoder_process.kill()
-                    except:
+                    except Exception:
                         pass
                 except Exception as e:
                     logger.warning(f"终止进程时出错: {e}")
@@ -2002,7 +2002,7 @@ class VideoEnhanceView(ft.Container):
             # 关闭编码器输入（触发编码器完成）
             try:
                 encoder_process.stdin.close()
-            except:
+            except Exception:
                 pass
             
             # 等待解码器完成
@@ -2040,9 +2040,9 @@ class VideoEnhanceView(ft.Container):
                     decoder_process.terminate()
                     try:
                         decoder_process.kill()
-                    except:
+                    except Exception:
                         pass
-            except:
+            except Exception:
                 pass
             
             try:
@@ -2050,9 +2050,9 @@ class VideoEnhanceView(ft.Container):
                     encoder_process.terminate()
                     try:
                         encoder_process.kill()
-                    except:
+                    except Exception:
                         pass
-            except:
+            except Exception:
                 pass
             
             return False
@@ -2062,14 +2062,14 @@ class VideoEnhanceView(ft.Container):
                 if 'decoder_process' in locals() and decoder_process.poll() is None:
                     logger.warning("清理残留的解码器进程...")
                     decoder_process.kill()
-            except:
+            except Exception:
                 pass
             
             try:
                 if 'encoder_process' in locals() and encoder_process.poll() is None:
                     logger.warning("清理残留的编码器进程...")
                     encoder_process.kill()
-            except:
+            except Exception:
                 pass
             
             # 清理临时音频文件
@@ -2227,7 +2227,7 @@ class VideoEnhanceView(ft.Container):
         
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
         
         if self.should_cancel:
@@ -2321,7 +2321,7 @@ class VideoEnhanceView(ft.Container):
             self._show_snackbar(f"已添加 {added_count} 个文件", ft.Colors.GREEN)
         try:
             self._page.update()
-        except:
+        except Exception:
             pass
     
     def cleanup(self) -> None:

--- a/src/views/media/video_watermark_view.py
+++ b/src/views/media/video_watermark_view.py
@@ -774,7 +774,7 @@ class VideoWatermarkView(ft.Container):
                 try:
                     file_size = file_path.stat().st_size
                     size_str = f"{file_size / 1024:.1f} KB" if file_size < 1024 * 1024 else f"{file_size / (1024 * 1024):.2f} MB"
-                except:
+                except Exception:
                     size_str = "未知"
                 
                 self.file_list_view.controls.append(

--- a/src/views/others/image_to_url_view.py
+++ b/src/views/others/image_to_url_view.py
@@ -336,7 +336,7 @@ class ImageToUrlView(ft.Container):
                                 from datetime import datetime
                                 expires_dt = datetime.fromisoformat(upload_result['expiresAt'].replace('Z', '+00:00'))
                                 expires_text = f" | 过期: {expires_dt.strftime('%Y-%m-%d %H:%M')}"
-                            except:
+                            except Exception:
                                 pass
                         
                         file_info_column.controls.append(

--- a/src/views/others/windows_update_view.py
+++ b/src/views/others/windows_update_view.py
@@ -435,7 +435,7 @@ class WindowsUpdateView(ft.Container):
             # 删除临时文件
             try:
                 Path(reg_file).unlink()
-            except:
+            except Exception:
                 pass
             
             # 检查是否执行成功
@@ -479,7 +479,7 @@ class WindowsUpdateView(ft.Container):
             # 删除临时文件
             try:
                 Path(reg_file).unlink()
-            except:
+            except Exception:
                 pass
             
             # 检查是否执行成功

--- a/src/views/settings_view.py
+++ b/src/views/settings_view.py
@@ -1733,7 +1733,7 @@ class SettingsView(ft.Container):
                         page = getattr(self, '_saved_page', self._page)
                         if page:
                             page.update()
-                    except:
+                    except Exception:
                         pass
     
     def _on_download_wallpaper(self, e: Optional[ft.ControlEvent] = None) -> None:
@@ -2504,7 +2504,7 @@ class SettingsView(ft.Container):
             self.cpu_threads_value_text.value = f"{threads if threads > 0 else '自动'}"
             try:
                 self._page.update()
-            except:
+            except Exception:
                 pass
             
             display_text = f"自动检测" if threads == 0 else f"{threads} 个线程"


### PR DESCRIPTION
Replace 136 bare `except:` with `except Exception:` across 36 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.